### PR TITLE
fix: rewrite let-chain conditionals for stable Rust

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -23,7 +23,7 @@ use crate::model::*;
 use crate::notify::{maybe_notify_changes, notify_update_available};
 use crate::process::kill::terminate_pid;
 use crate::process::ports::scan_ports;
-use crate::ui::icon::{IconVariant, create_template_icon};
+use crate::ui::icon::{create_template_icon, IconVariant};
 use crate::ui::menu::{
     build_menu_with_context, build_tooltip, collect_targets_for_all, format_command_label,
     parse_menu_action,
@@ -936,10 +936,10 @@ fn is_safe_path(path: &std::path::Path) -> bool {
         Err(_) => return false,
     };
     // Allow paths under home directory
-    if let Ok(home) = std::env::var("HOME")
-        && canonical.starts_with(&home)
-    {
-        return true;
+    if let Ok(home) = std::env::var("HOME") {
+        if canonical.starts_with(&home) {
+            return true;
+        }
     }
     // Allow /tmp and /var/folders (macOS temp)
     // Note: On macOS, /tmp -> /private/tmp and /var -> /private/var after canonicalization

--- a/src/integrations/brew.rs
+++ b/src/integrations/brew.rs
@@ -49,12 +49,12 @@ pub fn get_brew_managed_service(
     brew_services_map: &HashMap<String, String>,
 ) -> Option<String> {
     let potential_service = map_brew_service_from_cmd(cmd)?;
-    if let Some(status) = brew_services_map.get(&potential_service)
-        && status == "started"
-    {
-        let expected_port = get_default_port_for_service(&potential_service);
-        if Some(port) == expected_port {
-            return Some(potential_service);
+    if let Some(status) = brew_services_map.get(&potential_service) {
+        if status == "started" {
+            let expected_port = get_default_port_for_service(&potential_service);
+            if Some(port) == expected_port {
+                return Some(potential_service);
+            }
         }
     }
     None

--- a/src/integrations/docker.rs
+++ b/src/integrations/docker.rs
@@ -40,20 +40,20 @@ pub fn query_docker_port_map() -> Result<HashMap<u16, DockerContainerInfo>> {
             if seg.is_empty() {
                 continue;
             }
-            if let Some((left, _right)) = seg.split_once("->")
-                && let Some((_, host)) = left.rsplit_once(':')
-            {
-                if host.contains('-') {
-                    continue;
-                }
-                if let Ok(p) = host.parse::<u16>() {
-                    map.insert(
-                        p,
-                        DockerContainerInfo {
-                            name: name.clone(),
-                            id: id.clone(),
-                        },
-                    );
+            if let Some((left, _right)) = seg.split_once("->") {
+                if let Some((_, host)) = left.rsplit_once(':') {
+                    if host.contains('-') {
+                        continue;
+                    }
+                    if let Ok(p) = host.parse::<u16>() {
+                        map.insert(
+                            p,
+                            DockerContainerInfo {
+                                name: name.clone(),
+                                id: id.clone(),
+                            },
+                        );
+                    }
                 }
             }
         }

--- a/src/process/ports.rs
+++ b/src/process/ports.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::process::Command;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 
 use crate::model::ProcessInfo;
 
@@ -42,16 +42,16 @@ pub fn scan_ports(port_ranges: &[(u16, u16)]) -> Result<Vec<ProcessInfo>> {
                 current_cmd = Some(val.trim().to_string());
             }
             "n" => {
-                if let (Some(pid), Some(cmd)) = (current_pid, current_cmd.as_ref())
-                    && let Some(port) = parse_port_from_lsof(val.trim())
-                    && in_ranges(port, port_ranges)
-                    && seen.insert((port, pid))
-                {
-                    results.push(ProcessInfo {
-                        port,
-                        pid,
-                        command: cmd.clone(),
-                    });
+                if let (Some(pid), Some(cmd)) = (current_pid, current_cmd.as_ref()) {
+                    if let Some(port) = parse_port_from_lsof(val.trim()) {
+                        if in_ranges(port, port_ranges) && seen.insert((port, pid)) {
+                            results.push(ProcessInfo {
+                                port,
+                                pid,
+                                command: cmd.clone(),
+                            });
+                        }
+                    }
                 }
             }
             _ => {}


### PR DESCRIPTION
## Summary
- Replace unstable let-chain conditionals with equivalent nested `if let` checks in four files.
- Keep behavior unchanged while restoring compatibility with stable Rust toolchains.
- Isolate this compatibility fix from #33 config validation changes.

## Files
- `src/app.rs`
- `src/process/ports.rs`
- `src/integrations/brew.rs`
- `src/integrations/docker.rs`

## Validation
- `cargo check` ✅
- `cargo test` ✅