### PR TITLE
fix(utils): refresh command path cache with ttl

### DIFF
--- a/src/notify.rs
+++ b/src/notify.rs
@@ -73,11 +73,11 @@ fn notify(title: &str, body: &str) {
 fn notify_with_terminal_notifier(title: &str, body: &str) {
     let cmd = find_command("terminal-notifier");
     // Check if terminal-notifier exists (find_command falls back to name if not found)
-    if !std::path::Path::new(cmd).exists() && Command::new(cmd).arg("-help").output().is_err() {
+    if !std::path::Path::new(&cmd).exists() && Command::new(&cmd).arg("-help").output().is_err() {
         return;
     }
 
-    let _ = Command::new(cmd)
+    let _ = Command::new(&cmd)
         .args([
             "-title", title, "-message", body, "-sender", BUNDLE_ID, "-sound", "Glass",
         ])
@@ -87,14 +87,14 @@ fn notify_with_terminal_notifier(title: &str, body: &str) {
 /// Notify user that an update is available with clickable download link
 pub fn notify_update_available(version: &str, download_url: &str) {
     let cmd = find_command("terminal-notifier");
-    if !std::path::Path::new(cmd).exists() && Command::new(cmd).arg("-help").output().is_err() {
+    if !std::path::Path::new(&cmd).exists() && Command::new(&cmd).arg("-help").output().is_err() {
         return;
     }
 
     let title = format!("PortKiller v{} Available", version);
     let body = "Click to download the update";
 
-    let _ = Command::new(cmd)
+    let _ = Command::new(&cmd)
         .args([
             "-title",
             &title,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,25 +1,44 @@
+use std::collections::HashMap;
 use std::path::Path;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+const COMMAND_CACHE_TTL: Duration = Duration::from_secs(300);
+
+struct CacheEntry {
+    path: String,
+    cached_at: Instant,
+}
+
+static COMMAND_CACHE: OnceLock<Mutex<HashMap<&'static str, CacheEntry>>> = OnceLock::new();
 
 /// Find an executable in common Homebrew locations, falling back to PATH.
 /// Results are cached for efficiency.
-pub fn find_command(name: &str) -> &'static str {
-    // Use static caches for common commands
-    match name {
-        "docker" => {
-            static DOCKER: OnceLock<&'static str> = OnceLock::new();
-            DOCKER.get_or_init(|| find_in_paths(name, HOMEBREW_PATHS))
+pub fn find_command(name: &str) -> String {
+    if let Some(key) = tracked_command_key(name) {
+        let cache = COMMAND_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        let mut guard = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        if let Some(entry) = guard.get(key) {
+            if entry.cached_at.elapsed() < COMMAND_CACHE_TTL && is_cached_path_valid(&entry.path) {
+                return entry.path.clone();
+            }
         }
-        "brew" => {
-            static BREW: OnceLock<&'static str> = OnceLock::new();
-            BREW.get_or_init(|| find_in_paths(name, HOMEBREW_PATHS))
-        }
-        "terminal-notifier" => {
-            static NOTIFIER: OnceLock<&'static str> = OnceLock::new();
-            NOTIFIER.get_or_init(|| find_in_paths(name, HOMEBREW_PATHS))
-        }
-        _ => find_in_paths(name, HOMEBREW_PATHS),
+
+        let resolved = find_in_paths(name, HOMEBREW_PATHS);
+        guard.insert(
+            key,
+            CacheEntry {
+                path: resolved.clone(),
+                cached_at: Instant::now(),
+            },
+        );
+        return resolved;
     }
+
+    find_in_paths(name, HOMEBREW_PATHS)
 }
 
 const HOMEBREW_PATHS: &[&str] = &[
@@ -27,14 +46,28 @@ const HOMEBREW_PATHS: &[&str] = &[
     "/usr/local/bin",    // Intel Mac
 ];
 
-fn find_in_paths(name: &str, prefix_paths: &[&str]) -> &'static str {
+fn find_in_paths(name: &str, prefix_paths: &[&str]) -> String {
     for prefix in prefix_paths {
         let full_path = format!("{}/{}", prefix, name);
         if Path::new(&full_path).exists() {
-            // Leak the string to get a 'static lifetime (acceptable for small, cached strings)
-            return Box::leak(full_path.into_boxed_str());
+            return full_path;
         }
     }
-    // Fallback to PATH lookup
-    Box::leak(name.to_string().into_boxed_str())
+    name.to_string()
+}
+
+fn tracked_command_key(name: &str) -> Option<&'static str> {
+    match name {
+        "docker" => Some("docker"),
+        "brew" => Some("brew"),
+        "terminal-notifier" => Some("terminal-notifier"),
+        _ => None,
+    }
+}
+
+fn is_cached_path_valid(path: &str) -> bool {
+    if !Path::new(path).is_absolute() {
+        return true;
+    }
+    Path::new(path).exists()
 }


### PR DESCRIPTION
## Summary
- Replace permanent command path caches with a TTL-based cache for tracked commands (`brew`, `docker`, `terminal-notifier`).
- Re-resolve cached entries when TTL expires or when an absolute cached path no longer exists.
- Update notifier command execution sites to use borrowed command paths from the updated resolver.

## Why
Issue #35 reports that command paths are cached forever, so Homebrew reinstall/path changes can leave stale paths and break integrations at runtime.

## Validation
- `cargo check` ❌ blocked by pre-existing unstable let-chain syntax errors on upstream `master` (`src/app.rs`, `src/process/ports.rs`, `src/integrations/brew.rs`, `src/integrations/docker.rs`).
- `cargo test` ❌ blocked by the same pre-existing baseline errors.

Closes #35